### PR TITLE
Add install instructions to lwes

### DIFF
--- a/README
+++ b/README
@@ -35,3 +35,10 @@ For more information on developing with the LWES see
 http://www.lwes.org
 
 
+Mac Install Commands
+
+git clone https://github.com/lwes/lwes.git
+cd lwes
+./bootstrap && ./configure --disable-hardcore && make && make check
+sudo make install
+


### PR DESCRIPTION
Thanks for the help I have added lwes 

The build instructions worked, I have added them to the README

Quoted from the github message
"""
djnym said 2 days ago:
Yeah, so this works for me

% git clone https://github.com/lwes/lwes.git
% cd lwes
% ./bootstrap && ./configure --disable-hardcore && make && make check

you should then be able to

% sudo make install
"""
