### PR TITLE
Allow numeric and string literal default values in ESF.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+Version 1.1.1 (timrc)
+  * Allow numeric and string literal default values in ESF.
+    (Not stored in eventdb yet.)
+
 Version 1.1.0 (timrc)
   * Added BYTE, FLOAT, DOUBLE for parity with Erlang/Java
   * Added array types, required/optional/nullable and string-size to ESF parser.

--- a/src/lwes_esf_parser.l
+++ b/src/lwes_esf_parser.l
@@ -173,8 +173,15 @@ double          {
                   ((struct lwes_parser_state *) param)->in_str_size = 0;
                   return ')';
                 }
+"="             {
+                  return '=';
+                }
 ";"             {
                   return ';';
+                }
+\"[^\"]*\"      {
+                    *lvalp = (YYSTYPE)lwestext;
+                    return(LITERALSTRING);
                 }
 "#"[^\n]*       /* eat up one-line comments */
 [ \t]           ; /* ignore whitespace */

--- a/src/lwes_esf_parser_y.y
+++ b/src/lwes_esf_parser_y.y
@@ -49,7 +49,7 @@ void lwes_cleanup_attribute_state(void* param);
 
 %token YY_UINT16 YY_INT16 YY_UINT32 YY_INT32 YY_INT64 YY_UINT64 YY_BOOLEAN YY_STRING YY_IP_ADDR YY_BYTE YY_FLOAT YY_DOUBLE 
 %token YY_REQUIRED YY_OPTIONAL YY_NULLABLE
-%token EVENTWORD ATTRIBUTEWORD ATTRIBUTESIZE BADSIZE INVALID
+%token EVENTWORD ATTRIBUTEWORD ATTRIBUTESIZE BADSIZE INVALID LITERALSTRING
 
 %%
 
@@ -77,7 +77,7 @@ attributelist:
     | attributelist attribute
     ;
 
-attribute: check type check attributename check stringspec check arrayspec check ';' {
+attribute: check type check attributename check stringspec check arrayspec check defaultvalspec ';' {
         {
           struct lwes_parser_state* state = (struct lwes_parser_state *) param;
           if (state->lastType != NULL)
@@ -100,6 +100,30 @@ attribute: check type check attributename check stringspec check arrayspec check
              }
         }
     }
+    ;
+
+defaultvalspec:
+      /* empty */
+    | '=' literal
+    ;
+
+literal:
+      ATTRIBUTEWORD
+           {
+             /* TODO store this in the eventdb */
+             char* end;
+             int val = strtol(lweslval, &end, 0);
+             (void) val;
+             /* validate numeric */
+             if (0 != *end) 
+               {
+               lwes_yyerror(param, "Bad numeric default value.");
+               }
+           }
+    | LITERALSTRING
+           {
+             /* TODO store this in the eventdb */
+           }
     ;
 
 stringspec:

--- a/tests/test-extended.esf
+++ b/tests/test-extended.esf
@@ -11,9 +11,9 @@ Event2
   ip_addr t_ip_addr;   # test_ip_addr                 OPTIONAL, CALCULATED
   string  t_string;    # test_string                  OPTIONAL, CALCULATED, 50
 
-  byte    t_byte;      # test_bool_array              OPTIONAL, CALCULATED
-  float   t_float;     # test_bool_array              OPTIONAL, CALCULATED
-  double  t_double;    # test_bool_array              OPTIONAL, CALCULATED
+  byte    t_byte;      # test_byte                    OPTIONAL, CALCULATED
+  float   t_float;     # test_float                   OPTIONAL, CALCULATED
+  double  t_double;    # test_double                  OPTIONAL, CALCULATED
 
   boolean t_bool_ar[8];   # test_bool_array              OPTIONAL, CALCULATED
   optional byte maybeb;
@@ -21,5 +21,8 @@ Event2
   nullable byte possiblyb[8];
   required nullable string full_feature_string(32)[8];
   required nullable string unlimited_string[];
+
+  int16   d_int16 = 32767; # test_int16  with default value  OPTIONAL, CALCULATED
+  string   d_string = "some string"; # test_int16  with default value  OPTIONAL, CALCULATED
 }
 


### PR DESCRIPTION
Note: This only parses the ESF, defaults aren't stored in the eventdb yet.